### PR TITLE
fix(hook): formate each file in a global ctx for import reordering

### DIFF
--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -12,7 +12,7 @@ pre-commit="""sh -lc '
     case "$file" in
       *.rs)
         [ -f "$file" ] || continue
-        rustfmt "$file" || { echo "❌ rustfmt failed on $file"; exit 1; }
+        cargo fmt --all -- "$file" || { echo "❌ rustfmt failed on $file"; exit 1; }
         git add -- "$file"
         ;;
     esac


### PR DESCRIPTION
##Description

The pre-commit hook was using `rustfmt` directly on staged files.
This caused inconsistent formatting results compared to `cargo fmt --all`, especially around import reordering.

As a result, developers could commit code that passed the local pre-commit check but later failed CI checks running `cargo fmt --all --check.`

## Fix
Now using `cargo fmt --all -- "$file" ` to add a global context to a specific file formatting 